### PR TITLE
chore: ignore local CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# claude code
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to `.gitignore` so per-developer Claude Code guidance files stay local.
- No code changes; the README and existing docs remain the shared source of truth.

## Test plan
- [x] `git check-ignore -v CLAUDE.md` matches the new rule
- [x] Pre-commit lint hook (`npm run lint`) passes
- [ ] Reviewer confirms no `CLAUDE.md` is currently tracked in `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)